### PR TITLE
fix for problems with  $httpProvider.defaults.withCredentials = true; 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 ionic-service-analytics
 =======================
 
-Ionic Analytics Service. See the official docs here: http://docs.ionic.io/services/analytics/
+Ionic Analytics Service. See the official docs here: http://docs.ionic.io/v1.0/docs/analytics-from-scratch

--- a/ionic-analytics.js
+++ b/ionic-analytics.js
@@ -65,7 +65,8 @@ angular.module('ionic.service.analytics', ['ionic.service.core'])
           url: $ionicApp.getApiUrl() + '/api/v1/app/' + this.getAppId() + '/keys/write',
           headers: {
             'Authorization': "basic " + btoa(this.getAppId() + ':' + this.getApiKey())
-          }
+          },
+		  withCredentials: false
         };
         return $http(req);
       },
@@ -86,7 +87,8 @@ angular.module('ionic.service.analytics', ['ionic.service.core'])
           headers: {
             "Authorization": analyticsKey,
             "Content-Type": "application/json"
-          }
+          },
+		  withCredentials: false
         }
 
         return $http(req);
@@ -104,7 +106,8 @@ angular.module('ionic.service.analytics', ['ionic.service.core'])
           headers: {
             "Authorization": analyticsKey,
             "Content-Type": "application/json"
-          }
+          },
+		  withCredentials: false
         }
 
         return $http(req);

--- a/src/js/ionicAnalytics.js
+++ b/src/js/ionicAnalytics.js
@@ -59,7 +59,8 @@ angular.module('ionic.service.analytics', ['ionic.service.core'])
           url: $ionicApp.getApiUrl() + '/api/v1/app/' + this.getAppId() + '/keys/write',
           headers: {
             'Authorization': "basic " + btoa(this.getAppId() + ':' + this.getApiKey())
-          }
+          },
+		  withCredentials: false
         };
         return $http(req);
       },
@@ -80,7 +81,8 @@ angular.module('ionic.service.analytics', ['ionic.service.core'])
           headers: {
             "Authorization": analyticsKey,
             "Content-Type": "application/json"
-          }
+          },
+		  withCredentials: false
         }
 
         return $http(req);
@@ -98,7 +100,8 @@ angular.module('ionic.service.analytics', ['ionic.service.core'])
           headers: {
             "Authorization": analyticsKey,
             "Content-Type": "application/json"
-          }
+          },
+		  withCredentials: false
         }
 
         return $http(req);


### PR DESCRIPTION
if  $httpProvider.defaults.withCredentials = true; the requests are sent with credentials.
the analytics api requires a request without the credentials flag, so I made the requests explicitly set with withCredentials: false.

Not sure if that's the right approach to fix